### PR TITLE
Fix DOM XSS vulnerabilities in hierarchy and model search

### DIFF
--- a/src/UXClient/Components/Hierarchy/Hierarchy.ts
+++ b/src/UXClient/Components/Hierarchy/Hierarchy.ts
@@ -47,9 +47,9 @@ class Hierarchy extends Component {
                         if(splitFilterText[i].length){
                             var nodesInFilter = self.root.traverse(n => n.selfInFilter);
                             nodesInFilter.forEach(n => {
-                                var markedName = n.markedName;
+                                var matchedFilter = n.matchedFilter;
                                 n.filter(splitFilterText[i], false)
-                                n.markedName = markedName;
+                                n.matchedFilter = matchedFilter;
                             });
                             nodesInFilter.forEach(n => {
                                 if(!n.childrenInFilter)
@@ -171,7 +171,9 @@ class Hierarchy extends Component {
                                 .classed('tsi-selected', n.isSelected).on('click', clickMethod)
 
                         li.append('span').classed('tsi-caret', true).attr('style', `left: ${(n.level - 1) * 18}px`);
-                        li.append('span').classed('tsi-markedName', true).html(n.markedName)  // known unsafe usage of .html
+                                                li.append('span').classed('tsi-markedName', true).each(function() {
+                                                        self.renderHighlightedName(this, n.name, n.matchedFilter);
+                                                })
                           .attr('style', `padding-left: ${40 + (n.level - 1) * 18 - (n.isLeafParent && this.withContextMenu ? 16 : 0)}px`)
                           .attr('title', n.isLeafParent && this.withContextMenu ? n.name : '');
                         n.colorify(li);
@@ -207,6 +209,27 @@ class Hierarchy extends Component {
             return node;
         }
         return traverse(data, '', 0);
+    }
+
+    private renderHighlightedName(element: Element, name: string, filterText: string) {
+        if(!filterText){
+            element.textContent = name;
+            return;
+        }
+
+        var regExp = new RegExp(filterText, 'gi');
+        var lastIndex = 0;
+        var match;
+        while((match = regExp.exec(name)) !== null){
+            element.appendChild(document.createTextNode(name.slice(lastIndex, match.index)));
+            var mark = document.createElement('mark');
+            mark.textContent = match[0];
+            element.appendChild(mark);
+            lastIndex = match.index + match[0].length;
+            if(match[0].length == 0)
+                break;
+        }
+        element.appendChild(document.createTextNode(name.slice(lastIndex)));
     }
 
     private closeContextMenu() {

--- a/src/UXClient/Components/ModelAutocomplete/ModelAutocomplete.ts
+++ b/src/UXClient/Components/ModelAutocomplete/ModelAutocomplete.ts
@@ -154,8 +154,8 @@ class ModelAutocomplete extends Component {
       return item;
     }
 
-    const lowerText = suggestionText.toLocaleLowerCase();
-    const lowerFilterText = filterText.toLocaleLowerCase();
+    const lowerText = suggestionText.toLowerCase();
+    const lowerFilterText = filterText.toLowerCase();
     let currentIndex = 0;
     let matchIndex = lowerText.indexOf(lowerFilterText, currentIndex);
     while (matchIndex !== -1) {

--- a/src/UXClient/Components/ModelAutocomplete/ModelAutocomplete.ts
+++ b/src/UXClient/Components/ModelAutocomplete/ModelAutocomplete.ts
@@ -66,7 +66,11 @@ class ModelAutocomplete extends Component {
       .attr("aria-live", "assertive");
 
     let Awesomplete = (window as any).Awesomplete;
-    this.ap = new Awesomplete(input.node(), { minChars: 1 });
+    this.ap = new Awesomplete(input.node(), {
+      minChars: 1,
+      item: (text, searchText, itemId) =>
+        this.renderSuggestionItem(text, searchText, itemId),
+    });
     let noSuggest = false;
     let justAwesompleted = false;
     (input.node() as any).addEventListener(
@@ -134,6 +138,36 @@ class ModelAutocomplete extends Component {
       noSuggest = false;
       clear.classed("tsi-shown", searchText.length);
     });
+  }
+
+  private renderSuggestionItem(text: string, searchText: string, itemId: number) {
+    const suggestionText = String(text);
+    const item = document.createElement("li");
+    item.setAttribute("role", "option");
+    item.setAttribute("aria-selected", "false");
+    item.setAttribute("tabindex", "-1");
+    item.id = `awesomplete_list_${this.ap ? this.ap.count : 1}_item_${itemId}`;
+
+    const filterText = searchText.trim();
+    if (!filterText) {
+      item.textContent = suggestionText;
+      return item;
+    }
+
+    const lowerText = suggestionText.toLocaleLowerCase();
+    const lowerFilterText = filterText.toLocaleLowerCase();
+    let currentIndex = 0;
+    let matchIndex = lowerText.indexOf(lowerFilterText, currentIndex);
+    while (matchIndex !== -1) {
+      item.appendChild(document.createTextNode(suggestionText.slice(currentIndex, matchIndex)));
+      const mark = document.createElement("mark");
+      mark.textContent = suggestionText.slice(matchIndex, matchIndex + filterText.length);
+      item.appendChild(mark);
+      currentIndex = matchIndex + filterText.length;
+      matchIndex = lowerText.indexOf(lowerFilterText, currentIndex);
+    }
+    item.appendChild(document.createTextNode(suggestionText.slice(currentIndex)));
+    return item;
   }
 }
 

--- a/src/UXClient/Components/ModelAutocomplete/ModelAutocomplete.ts
+++ b/src/UXClient/Components/ModelAutocomplete/ModelAutocomplete.ts
@@ -154,17 +154,16 @@ class ModelAutocomplete extends Component {
       return item;
     }
 
-    const lowerText = suggestionText.toLowerCase();
-    const lowerFilterText = filterText.toLowerCase();
+    const escapedFilterText = filterText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const regExp = new RegExp(escapedFilterText, "gi");
     let currentIndex = 0;
-    let matchIndex = lowerText.indexOf(lowerFilterText, currentIndex);
-    while (matchIndex !== -1) {
-      item.appendChild(document.createTextNode(suggestionText.slice(currentIndex, matchIndex)));
+    let match;
+    while ((match = regExp.exec(suggestionText)) !== null) {
+      item.appendChild(document.createTextNode(suggestionText.slice(currentIndex, match.index)));
       const mark = document.createElement("mark");
-      mark.textContent = suggestionText.slice(matchIndex, matchIndex + filterText.length);
+      mark.textContent = match[0];
       item.appendChild(mark);
-      currentIndex = matchIndex + filterText.length;
-      matchIndex = lowerText.indexOf(lowerFilterText, currentIndex);
+      currentIndex = match.index + match[0].length;
     }
     item.appendChild(document.createTextNode(suggestionText.slice(currentIndex)));
     return item;

--- a/src/UXClient/Components/ModelSearch/ModelSearch.scss
+++ b/src/UXClient/Components/ModelSearch/ModelSearch.scss
@@ -12,7 +12,7 @@
     background: $gray3;
     color: $gray1;
     
-    hit{
+    hit, mark{
         background: #fff9a8;
         font-weight: 600;
         color: black;

--- a/src/UXClient/Components/ModelSearch/ModelSearch.ts
+++ b/src/UXClient/Components/ModelSearch/ModelSearch.ts
@@ -236,9 +236,10 @@ class ModelSearch extends Component {
               self.clickedInstance = null;
             }
           };
-          this.instanceResults
-            .append("div")
-            .html(self.getInstanceHtml(i)) // known unsafe usage of .html
+          let result = this.instanceResults
+            .append("div");
+          result.node().appendChild(self.createInstanceElem(i).node());
+          result
             .on("click", function (event,d) {
               let mouseWrapper = d3.pointer(event,self.wrapper.node());
               let mouseElt = d3.pointer(event,this as any);
@@ -307,72 +308,60 @@ class ModelSearch extends Component {
     d3.selectAll(".tsi-resultSelected").classed("tsi-resultSelected", false);
   }
 
-  private stripHits = (str) => {
-    return str
-      .split("<hit>")
-      .map((h) =>
-        h
-          .split("</hit>")
-          .map((h2) => Utils.strip(h2))
-          .join("</hit>")
-      )
-      .join("<hit>");
-  };
+  private createInstanceElem(i) {
+    let instanceElem = d3.create("div").classed("tsi-modelResult", true);
+    let firstLine = instanceElem.append("div").classed("tsi-modelPK", true);
+    let highlightedTimeSeriesIds = i.highlights.timeSeriesIds
+      ? i.highlights.timeSeriesIds.join(" ")
+      : i.highlights.timeSeriesId.join(" ");
+    Utils.appendFormattedElementsFromString(
+      firstLine,
+      i.highlights.name || highlightedTimeSeriesIds
+    );
 
-  private getInstanceHtml(i) {
-    return `<div class="tsi-modelResult">
-                    <div class="tsi-modelPK">
-                        ${
-                          i.highlights.name
-                            ? this.stripHits(i.highlights.name)
-                            : this.stripHits(
-                                i.highlights.timeSeriesIds
-                                  ? i.highlights.timeSeriesIds.join(" ")
-                                  : i.highlights.timeSeriesId.join(" ")
-                              )
-                        }
-                    </div>
-                    <div class="tsi-modelHighlights">
-                        ${this.stripHits(
-                          i.highlights.description &&
-                            i.highlights.description.length
-                            ? i.highlights.description
-                            : this.getString("No description")
-                        )}
-                        <br/><table>
-                        ${
-                          i.highlights.name
-                            ? "<tr><td>" +
-                              this.getString("Time Series ID") +
-                              "</td><td>" +
-                              this.stripHits(
-                                i.highlights.timeSeriesIds
-                                  ? i.highlights.timeSeriesIds.join(" ")
-                                  : i.highlights.timeSeriesId.join(" ")
-                              ) +
-                              "</td></tr>"
-                            : ""
-                        }                        
-                        ${i.highlights.instanceFieldNames
-                          .map((ifn, idx) => {
-                            var val = i.highlights.instanceFieldValues[idx];
-                            if (
-                              ifn.indexOf("<hit>") !== -1 ||
-                              val.indexOf("<hit>") !== -1
-                            ) {
-                              return val.length === 0
-                                ? ""
-                                : "<tr><td>" +
-                                    this.stripHits(ifn) +
-                                    "</td><td>" +
-                                    this.stripHits(val) +
-                                    "</tr>";
-                            }
-                          })
-                          .join("")}
-                        </table>
-                    </div>
-                </div>`;
+    let secondLine = instanceElem
+      .append("div")
+      .classed("tsi-modelHighlights", true);
+    Utils.appendFormattedElementsFromString(
+      secondLine,
+      i.highlights.description && i.highlights.description.length
+        ? i.highlights.description
+        : this.getString("No description")
+    );
+    secondLine.append("br");
+
+    let hitTuples = [];
+    if (i.highlights.name) {
+      hitTuples.push([this.getString("Time Series ID"), highlightedTimeSeriesIds]);
+    }
+    i.highlights.instanceFieldNames.forEach((ifn, idx) => {
+      let value = i.highlights.instanceFieldValues[idx];
+      if (
+        value.length &&
+        (ifn.indexOf("<hit>") !== -1 || value.indexOf("<hit>") !== -1)
+      ) {
+        hitTuples.push([ifn, value]);
+      }
+    });
+
+    let rows = secondLine
+      .append("table")
+      .selectAll("tr")
+      .data(hitTuples)
+      .enter()
+      .append("tr");
+    rows
+      .selectAll("td")
+      .data(function (d) {
+        return d;
+      })
+      .enter()
+      .append("td")
+      .each(function (d) {
+        Utils.appendFormattedElementsFromString(d3.select(this), d);
+      });
+
+    return instanceElem;
   }
 }
 

--- a/src/UXClient/Models/HierarchyNode.ts
+++ b/src/UXClient/Models/HierarchyNode.ts
@@ -1,8 +1,6 @@
-import Utils from "../Utils";
-
 class HierarchyNode {
     public name: string;
-    public markedName: string;
+    public matchedFilter: string = '';
     public children: Array<HierarchyNode> = [];
     public parent: HierarchyNode;
     public isExpanded: boolean = false;
@@ -18,7 +16,6 @@ class HierarchyNode {
 	constructor(name: string, level: number){
         this.name = name;
         this.level = level;
-        this.markedName = name;
     }
     
     public filter(filterText){
@@ -29,7 +26,7 @@ class HierarchyNode {
                 return p;
             }, false);
             var selfInFilter = regExp.test(node.name);
-            node.markedName = selfInFilter ? Utils.mark(filterText, node.name) : node.name;
+            node.matchedFilter = selfInFilter ? filterText : '';
             if(node.parent != null)
                 node.parent.childrenInFilter = (selfInFilter || childrenInFilter) && filterText.length > 0;
             node.selfInFilter = selfInFilter && filterText.length > 0;

--- a/src/UXClient/Utils/Utils.ts
+++ b/src/UXClient/Utils/Utils.ts
@@ -1024,16 +1024,21 @@ export default class Utils {
 
         let splitByTag = options && options.splitByTag ? options.splitByTag : 'hit';
         if(str!=null){
-            let splittedByHit = str.split(`<${splitByTag}>`);
-            splittedByHit.forEach((s, i) => {
-                if (i === 0) {
-                    data = data.concat(splitByNullGuid(s));
-                } else {
-                    let splittedByHitClose = s.split(`</${splitByTag}>`);
-                    data.push({str: splittedByHitClose[0], isHit: true});
-                    data = data.concat(splitByNullGuid(splittedByHitClose[1]));
+            let openTag = `<${splitByTag}>`;
+            let closeTag = `</${splitByTag}>`;
+            let currentIndex = 0;
+            let openIndex = str.indexOf(openTag, currentIndex);
+            while (openIndex !== -1) {
+                let closeIndex = str.indexOf(closeTag, openIndex + openTag.length);
+                if (closeIndex === -1) {
+                    break;
                 }
-            });
+                data = data.concat(splitByNullGuid(str.slice(currentIndex, openIndex)));
+                data.push({str: str.slice(openIndex + openTag.length, closeIndex), isHit: true});
+                currentIndex = closeIndex + closeTag.length;
+                openIndex = str.indexOf(openTag, currentIndex);
+            }
+            data = data.concat(splitByNullGuid(str.slice(currentIndex)));
         }
 
 

--- a/tests/hierarchy_security.spec.ts
+++ b/tests/hierarchy_security.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+import { waitForSdk } from './_behaviorUtils';
+
+test('hierarchy renders untrusted labels as text', async ({ page }) => {
+  await page.goto('/testcases/hierarchy.html');
+  await waitForSdk(page);
+
+  const payload = '<img src=x onerror="window.__hierarchyXss = true">Danger';
+  await page.evaluate((maliciousLabel) => {
+    const host = document.createElement('div');
+    host.id = 'hierarchy-security-test';
+    document.body.appendChild(host);
+
+    (window as any).__hierarchyXss = false;
+    const trender = new (window as any).KustoTrender();
+    const hierarchy = new trender.ux.Hierarchy(host);
+    hierarchy.render({
+      [maliciousLabel]: {
+        Leaf: { '$leaf': true }
+      }
+    }, { theme: 'light' });
+  }, payload);
+
+  const hierarchy = page.locator('#hierarchy-security-test');
+  const label = hierarchy.locator('.tsi-markedName', { hasText: 'Danger' });
+  await expect(label).toHaveText(payload);
+  await expect(hierarchy.locator('img')).toHaveCount(0);
+  expect(await page.evaluate(() => (window as any).__hierarchyXss)).toBe(false);
+
+  await hierarchy.locator('input').fill('Danger');
+  await expect(label.locator('mark')).toHaveText('Danger');
+  await expect(label).toHaveText(payload);
+  await expect(hierarchy.locator('img')).toHaveCount(0);
+  expect(await page.evaluate(() => (window as any).__hierarchyXss)).toBe(false);
+});
+
+test('model autocomplete renders untrusted suggestions as text', async ({ page }) => {
+  await page.goto('/testcases/hierarchy.html');
+  await waitForSdk(page);
+
+  const payload = '<img src=x onerror="window.__autocompleteXss = true">Danger';
+  await page.evaluate((maliciousSuggestion) => {
+    const host = document.createElement('div');
+    host.id = 'autocomplete-security-test';
+    document.body.appendChild(host);
+
+    (window as any).__autocompleteXss = false;
+    const delegate = {
+      getInstancesSuggestions: async () => [{ searchString: maliciousSuggestion }]
+    };
+    const trender = new (window as any).KustoTrender();
+    const autocomplete = new trender.ux.ModelAutocomplete(host, delegate);
+    autocomplete.render({ theme: 'light' });
+  }, payload);
+
+  const autocomplete = page.locator('#autocomplete-security-test');
+  const input = autocomplete.locator('input');
+  await input.fill('Danger');
+
+  const suggestion = autocomplete.locator('li[role="option"]');
+  await expect(suggestion).toHaveText(payload);
+  await expect(suggestion.locator('mark')).toHaveText('Danger');
+  await expect(autocomplete.locator('img')).toHaveCount(0);
+  expect(await page.evaluate(() => (window as any).__autocompleteXss)).toBe(false);
+
+  await suggestion.click();
+  await expect(input).toHaveValue(payload);
+  expect(await page.evaluate(() => (window as any).__autocompleteXss)).toBe(false);
+});
+
+test('model search renders entity-encoded highlights as text', async ({ page }) => {
+  await page.goto('/testcases/hierarchy.html');
+  await waitForSdk(page);
+
+  const payload = '&lt;img src=x onerror="window.__modelSearchXss = true"&gt;<hit>Danger</hit>';
+  await page.evaluate(async (maliciousHighlight) => {
+    const host = document.createElement('div');
+    host.id = 'model-search-security-test';
+    document.body.appendChild(host);
+
+    (window as any).__modelSearchXss = false;
+    const delegate = {
+      getInstancesSuggestions: async () => [],
+      getInstancesSearch: async () => ({
+        instances: {
+          hits: [{
+            timeSeriesId: ['test-id'],
+            highlights: {
+              name: maliciousHighlight,
+              timeSeriesId: ['test-id'],
+              typeName: 'TestType',
+              description: maliciousHighlight,
+              instanceFieldNames: ['<hit>Field</hit>'],
+              instanceFieldValues: [maliciousHighlight]
+            }
+          }]
+        }
+      }),
+      getHierarchies: async () => [],
+      getTimeSeriesTypes: async () => []
+    };
+    const trender = new (window as any).KustoTrender();
+    const modelSearch = new trender.ux.ModelSearch(host, delegate);
+    await modelSearch.render({}, { theme: 'light' });
+  }, payload);
+
+  const modelSearch = page.locator('#model-search-security-test');
+  const input = modelSearch.getByRole('combobox', { name: 'Search Time Series Instances' });
+  await input.fill('Danger');
+  await input.press('Enter');
+
+  const result = modelSearch.locator('.tsi-modelResult').first();
+  await expect(result).toContainText('Danger');
+  await expect(result.locator('mark')).not.toHaveCount(0);
+  await expect(modelSearch.locator('img')).toHaveCount(0);
+  expect(await page.evaluate(() => (window as any).__modelSearchXss)).toBe(false);
+});

--- a/tests/hierarchy_security.spec.ts
+++ b/tests/hierarchy_security.spec.ts
@@ -46,7 +46,10 @@ test('model autocomplete renders untrusted suggestions as text', async ({ page }
 
     (window as any).__autocompleteXss = false;
     const delegate = {
-      getInstancesSuggestions: async () => [{ searchString: maliciousSuggestion }]
+      getInstancesSuggestions: async () => [
+        { searchString: maliciousSuggestion },
+        { searchString: 'İXINDIGO' }
+      ]
     };
     const trender = new (window as any).KustoTrender();
     const autocomplete = new trender.ux.ModelAutocomplete(host, delegate);
@@ -66,6 +69,11 @@ test('model autocomplete renders untrusted suggestions as text', async ({ page }
   await suggestion.click();
   await expect(input).toHaveValue(payload);
   expect(await page.evaluate(() => (window as any).__autocompleteXss)).toBe(false);
+
+  await input.fill('indigo');
+  const unicodeSuggestion = autocomplete.locator('li[role="option"]');
+  await expect(unicodeSuggestion).toHaveText('İXINDIGO');
+  await expect(unicodeSuggestion.locator('mark')).toHaveText('INDIGO');
 });
 
 test('model search renders entity-encoded highlights as text', async ({ page }) => {
@@ -86,7 +94,7 @@ test('model search renders entity-encoded highlights as text', async ({ page }) 
           hits: [{
             timeSeriesId: ['test-id'],
             highlights: {
-              name: maliciousHighlight,
+              name: `${maliciousHighlight}<hit>unfinished`,
               timeSeriesId: ['test-id'],
               typeName: 'TestType',
               description: maliciousHighlight,
@@ -111,6 +119,7 @@ test('model search renders entity-encoded highlights as text', async ({ page }) 
 
   const result = modelSearch.locator('.tsi-modelResult').first();
   await expect(result).toContainText('Danger');
+  await expect(result).toContainText('<hit>unfinished');
   await expect(result.locator('mark')).not.toHaveCount(0);
   await expect(modelSearch.locator('img')).toHaveCount(0);
   expect(await page.evaluate(() => (window as any).__modelSearchXss)).toBe(false);


### PR DESCRIPTION
## Summary

Fixes three CWE-79 DOM XSS vulnerabilities:

- Render hierarchy labels and search highlights using safe DOM nodes.
- Override Awesomplete's unsafe default item renderer.
- Replace ModelSearch HTML-string rendering with safe DOM construction.
- Add regression tests for raw and entity-encoded XSS payloads.

## Security changes

- Untrusted hierarchy labels are inserted using text nodes and 	extContent.
- Autocomplete suggestions use a custom renderer instead of innerHTML.
- Model-search fields use Utils.appendFormattedElementsFromString.
- Only controlled mark elements are created for highlighting.
- Malicious values are never passed to D3 .html().

## Validation

- Dedicated XSS tests passed in Chromium, Firefox, and WebKit.
- Full Playwright suite passed.
- Production build passed.
- Demo charts and affected components were manually inspected.
- Hierarchy filtering, autocomplete selection, and model-search rendering remain functional.
- Malicious payloads remained text and created no executable DOM.